### PR TITLE
Last round code & payment investigation

### DIFF
--- a/crosstalk/models.py
+++ b/crosstalk/models.py
@@ -25,9 +25,9 @@ class Constants(BaseConstants):
     players_per_group = 4
     num_rounds = 50
 
-    # """variables for randomish end round, used in the intro app at the mo"""
-    # min_rounds = 20
-    # proba_next_round = 0.5
+    """variables for randomish end round, used in the intro app at the mo"""
+    min_rounds = 2
+    proba_next_round = 0.5
 
     points_per_currency = 60  # 60pts is £1
 
@@ -54,22 +54,43 @@ class Subsession(BaseSubsession):
     The inconveninent is that if 3 people read the instructions, 2 get 5 and 1 gets 6,
     if one of the 5 one gives up and quits the other two cannot play together. So not ideal
     """
-    def group_by_arrival_time_method(self, waiting_players):
-        # print("starting group_by_arrival_time_method")
-        from collections import defaultdict
-        d = defaultdict(list)
-        for p in waiting_players:
-            category = p.participant.vars['last_round']
-            players_with_this_category = d[category]
-            players_with_this_category.append(p)
-            if len(players_with_this_category) == 4:
-                # print("forming group", players_with_this_category)
-                # print('last_round is', p.participant.vars['last_round'])
-                return players_with_this_category
+    # def group_by_arrival_time_method(self, waiting_players):
+    #     # print("starting group_by_arrival_time_method")
+    #     from collections import defaultdict
+    #     d = defaultdict(list)
+    #     for p in waiting_players:
+    #         category = p.participant.vars['last_round']
+    #         players_with_this_category = d[category]
+    #         players_with_this_category.append(p)
+    #         if len(players_with_this_category) == 4:
+    #             # print("forming group", players_with_this_category)
+    #             # print('last_round is', p.participant.vars['last_round'])
+    #             return players_with_this_category
+    pass
 
 
 class Group(BaseGroup):
-    pass
+    """Field of the number of rounds. Each group gets attributed a number of rounds"""
+    last_round = models.IntegerField()
+
+    def get_random_number_of_rounds(self):
+        num_groups = int(self.session.num_participants / 2)
+        list_num_rounds = []
+        for _ in range(num_groups):
+            number = Constants.min_rounds
+            while Constants.proba_next_round < random.random():
+                number += 1
+            list_num_rounds.append(number)
+        return list_num_rounds
+
+    def set_last_round_per_group(self):
+        """ random last round code. With the function from above,
+            we attribute the different elements in the list to each group."""
+        list_num_rounds = self.group.get_random_number_of_rounds()
+        group_number_of_rounds = itertools.cycle(list_num_rounds)
+        for g in self.get_groups():
+            g.last_round = next(group_number_of_rounds)
+            print('New number of rounds', g.last_round)
 
 
 class Player(BasePlayer):

--- a/crosstalk/models.py
+++ b/crosstalk/models.py
@@ -146,7 +146,7 @@ class Player(BasePlayer):
 
     payoff_high = models.CurrencyField()
     payoff_low = models.CurrencyField()
-    payment = models.CurrencyField()
+    total_payoff = models.CurrencyField()
 
     left_hanging = models.CurrencyField()
 
@@ -168,7 +168,7 @@ class Player(BasePlayer):
                     opponents.append(opponent)
         return opponents
 
-    def set_payoff(self):
+    def set_payoffs(self):
         """
         The payoff function layout is from the prisoner template.
         There is one matrix per game using two separate decision variables.
@@ -210,6 +210,7 @@ class Player(BasePlayer):
         }
         self.payoff_low = payoff_matrix_low[self.decision_low][opponents[1].decision_low]
         # print(self.decision_low)
-        self.payment = self.payoff_high + self.payoff_low
+        self.total_payoff = self.payoff_high + self.payoff_low
+        self.payoff = self.payoff_high + self.payoff_low
         # print('self.payment', self.payment)
         # print('Player ID', self.id_in_group)

--- a/crosstalk/templates/crosstalk/SetLastRound.html
+++ b/crosstalk/templates/crosstalk/SetLastRound.html
@@ -13,8 +13,17 @@
         }
     </style>
 
-{% block content %}
 {% endblock %}
+
+{% block content %}
+
+<div style="display:none;">
+    <p>
+        <div style="display: flex; justify-content: flex-end">
+        {% next_button %}
+        </div>
+    </p>
+</div>
 
 <!---This page is useless. I only need it to set the subgroups/treatments in control and the last round.--->
 

--- a/crosstalk/templates/crosstalk/SetLastRound.html
+++ b/crosstalk/templates/crosstalk/SetLastRound.html
@@ -1,0 +1,21 @@
+{% extends "global/Page.html" %}
+{% load otree static %}
+
+
+{% block title %}
+
+{% endblock %}
+
+{% block styles %}
+    <style>
+        .otree-timer {
+            display: none;
+        }
+    </style>
+
+{% block content %}
+{% endblock %}
+
+<!---This page is useless. I only need it to set the subgroups/treatments in control and the last round.--->
+
+{% endblock %}

--- a/crosstalk/tests.py
+++ b/crosstalk/tests.py
@@ -6,8 +6,10 @@ from .models import Constants
 
 class PlayerBot(Bot):
     def play_round(self):
+        if self.round_number == 1:
+            yield pages.SetLastRound
         if self.round_number <= self.participant.vars['last_round']:
-            yield pages.Decision, {"decision_high": 1, "decision_low": 3}
+            yield pages.Decision, {"decision_high": 2, "decision_low": 4}
             # assert 'Both of you chose to Cooperate' in self.html  # no clue what this is
             # assert self.player.payoff == Constants.both_cooperate_payoff  # no clue what this is
             # if self.round_number % 2 == 0:
@@ -20,7 +22,7 @@ class PlayerBot(Bot):
 
         if self.round_number == self.participant.vars['last_round']:
             yield pages.End
-            # yield pages.Demographics, {"age": '22', "gender": 'Female', "income": '£10.000 - £29.999',
-            #                            "education": 'Postgraduate degree', "ethnicity": 'White'}
+            yield pages.Demographics, {"age": '22', "gender": 'Female', "income": '£10.000 - £29.999',
+                                       "education": 'Postgraduate degree', "ethnicity": 'White'}
             yield pages.Payment
             yield pages.ProlificLink

--- a/introduction_cross/models.py
+++ b/introduction_cross/models.py
@@ -21,9 +21,9 @@ class Constants(BaseConstants):
     players_per_group = 4
     num_rounds = 1
 
-    """variables for randomish next round"""
-    min_rounds = 2
-    proba_next_round = 0.5
+    # """variables for randomish next round"""
+    # min_rounds = 2
+    # proba_next_round = 0.5
 
     """
     Donation game payoff
@@ -48,32 +48,34 @@ class Subsession(BaseSubsession):
         This is for the 50% chance of another round. We create a function for clarity below in the creating_session().
         We create a list of different number of rounds that is as long as there are groups.
     """
-    def get_random_number_of_rounds(self):
-        num_groups = int(self.session.num_participants / 2)
-        list_num_rounds = []
-        for _ in range(num_groups):
-            number = Constants.min_rounds
-            while Constants.proba_next_round < random.random():
-                number += 1
-            list_num_rounds.append(number)
-        return list_num_rounds
-
-    def creating_session(self):
-        """ random last round code. With the function from above,
-                we attribute the different elements in the list to each group."""
-        list_num_rounds = self.get_random_number_of_rounds()
-        group_number_of_rounds = itertools.cycle(list_num_rounds)
-        for g in self.get_groups():
-            g.last_round = next(group_number_of_rounds)
-            print('New number of rounds', g.last_round)
-        for p in self.get_players():
-            p.participant.vars['last_round'] = p.group.last_round
-            print('vars last_round is', p.participant.vars['last_round'])
+    # def get_random_number_of_rounds(self):
+    #     num_groups = int(self.session.num_participants / 2)
+    #     list_num_rounds = []
+    #     for _ in range(num_groups):
+    #         number = Constants.min_rounds
+    #         while Constants.proba_next_round < random.random():
+    #             number += 1
+    #         list_num_rounds.append(number)
+    #     return list_num_rounds
+    #
+    # def creating_session(self):
+    #     """ random last round code. With the function from above,
+    #             we attribute the different elements in the list to each group."""
+    #     list_num_rounds = self.get_random_number_of_rounds()
+    #     group_number_of_rounds = itertools.cycle(list_num_rounds)
+    #     for g in self.get_groups():
+    #         g.last_round = next(group_number_of_rounds)
+    #         print('New number of rounds', g.last_round)
+    #     for p in self.get_players():
+    #         p.participant.vars['last_round'] = p.group.last_round
+    #         print('vars last_round is', p.participant.vars['last_round'])
+    pass
 
 
 class Group(BaseGroup):
-    """Field of the number of rounds. Each group gets attributed a number of rounds"""
-    last_round = models.IntegerField()
+    # """Field of the number of rounds. Each group gets attributed a number of rounds"""
+    # last_round = models.IntegerField()
+    pass
 
 
 class Player(BasePlayer):

--- a/introduction_cross/templates/introduction_cross/Instructions2.html
+++ b/introduction_cross/templates/introduction_cross/Instructions2.html
@@ -30,7 +30,7 @@
                     You <b>pay {{ Constants.c_high }} pts</b> for Participant <font color="blue">2</font> to <b>receive {{ Constants.b_high }} pts</b>.
                 </li>
                 <li>
-                    You <b>pay 0 pts</b>for Participant <font color="blue">2</font> to <b>receive 0 pts</b>.
+                    You <b>pay 0 pts</b> for Participant <font color="blue">2</font> to <b>receive 0 pts</b>.
                 </li>
             </ul>
             </div>

--- a/settings.py
+++ b/settings.py
@@ -6,7 +6,7 @@ from os import environ
 # e.g. self.session.config['participation_fee']
 
 SESSION_CONFIG_DEFAULTS = {
-    'real_world_currency_per_point': 1.00,
+    'real_world_currency_per_point': 0.016666667,
     'participation_fee': 3.00,
     'doc': "",
 }
@@ -17,7 +17,7 @@ SESSION_CONFIGS = [
     {
         'name': 'crosstalk',
         'display_name': "Crosstalk game",
-        'num_demo_participants': 4,
+        'num_demo_participants': 12,
         'app_sequence': ['introduction_cross', 'crosstalk'],
         'use_browser_bots': False
     },

--- a/settings.py
+++ b/settings.py
@@ -87,13 +87,13 @@ ADMIN_PASSWORD = environ.get('OTREE_ADMIN_PASSWORD')
 
 
 # Consider '', None, and '0' to be empty/false
-DEBUG = (environ.get('OTREE_PRODUCTION') in {None, '', '0'})
-DEBUG = True
-DEMO_PAGE_INTRO_HTML = """
-Here are various games implemented with 
-oTree. These games are open
-source, and you can modify them as you wish.
-"""
+# DEBUG = (environ.get('OTREE_PRODUCTION') in {None, '', '0'})
+# DEBUG = True
+# DEMO_PAGE_INTRO_HTML = """
+# Here are various games implemented with
+# oTree. These games are open
+# source, and you can modify them as you wish.
+# """
 
 # don't share this with anybody.
 SECRET_KEY = 'q=ig%=7m1hg%*%^_7e9!%xrrdpi!g+i=n7vhn4l%uuw@!6_#w*'


### PR DESCRIPTION
Last round code is assigned after the waitroom in crosstalk. HAd to log it in participant.vars so that it carries on to the next round. Needs more testing
Removed DEBUG mode code from settings.py
updated the tests.py
Had a deep look at payment to find a way to have the bonus displayed somewhere in the data so that I don't have to do math for 400 ppl... bit complicated but at the mo I have it displayed in the admin interface but not the data sheet.